### PR TITLE
feat: implement tool output truncation with head+tail strategy

### DIFF
--- a/cli/toolOutputTruncation.test.ts
+++ b/cli/toolOutputTruncation.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Unit tests for cli/toolOutputTruncation.ts
+ *
+ * Coverage goals:
+ *   - estimateTokenCount: ASCII, non-ASCII, mixed, empty, and boundary strings
+ *   - truncateToolOutput: pass-through below threshold, head+tail split, marker
+ *     content, custom options, edge cases (ratio=0, ratio=1, very short output)
+ *   - truncateShellOutput: stdout truncated, stderr/exitCode preserved
+ *   - applyToolOutputTruncation: exempt tools, non-exempt tools, options forwarded
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_HEAD_RATIO,
+  DEFAULT_TOKEN_THRESHOLD,
+  TRUNCATION_EXEMPT_TOOLS,
+  applyToolOutputTruncation,
+  estimateTokenCount,
+  truncateShellOutput,
+  truncateToolOutput,
+} from './toolOutputTruncation.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a string of `n` ASCII characters. */
+function asciiString(n: number): string {
+  return 'a'.repeat(n)
+}
+
+/** Build a string of `n` CJK characters (each is non-ASCII, ~1 token/char). */
+function cjkString(n: number): string {
+  // U+4E2D is '中', a common CJK character.
+  return '\u4e2d'.repeat(n)
+}
+
+// ─── estimateTokenCount ───────────────────────────────────────────────────────
+
+describe('estimateTokenCount', () => {
+  it('returns 0 for an empty string', () => {
+    expect(estimateTokenCount('')).toBe(0)
+  })
+
+  it('estimates ASCII text at ~4 chars per token', () => {
+    // 400 ASCII chars ÷ 4 = 100 tokens
+    const tokens = estimateTokenCount(asciiString(400))
+    expect(tokens).toBe(100)
+  })
+
+  it('estimates pure ASCII string of 1 char as 1 token', () => {
+    expect(estimateTokenCount('x')).toBe(1)
+  })
+
+  it('estimates large ASCII strings proportionally', () => {
+    // 8 000 chars → 2 000 tokens
+    const tokens = estimateTokenCount(asciiString(8_000))
+    expect(tokens).toBe(2_000)
+  })
+
+  it('estimates non-ASCII (CJK) text at a higher token density', () => {
+    // CJK chars-per-token ≈ 0.77, so 100 CJK chars → ceil(100/0.77) ≈ 130 tokens
+    const tokens = estimateTokenCount(cjkString(100))
+    // Should be substantially more than 25 (the ASCII estimate would be)
+    expect(tokens).toBeGreaterThan(50)
+    // And in the rough ballpark of 130
+    expect(tokens).toBeLessThanOrEqual(150)
+  })
+
+  it('uses only the first 1000 chars to determine the character ratio', () => {
+    // Build a 2000-char string: first 1000 are ASCII, next 1000 are CJK.
+    // The sampler only sees the ASCII half → estimate should behave like ASCII.
+    const mixed = asciiString(1_000) + cjkString(1_000)
+    const pureAscii = asciiString(2_000)
+    // Both strings have the same length; the mixed one encodes the CJK half
+    // with the ASCII density because only the first 1000 chars are sampled.
+    // They should produce similar (not wildly different) estimates.
+    const mixedTokens = estimateTokenCount(mixed)
+    const asciiTokens = estimateTokenCount(pureAscii)
+    expect(Math.abs(mixedTokens - asciiTokens)).toBeLessThan(200)
+  })
+
+  it('handles strings exactly at the sample boundary (1000 chars)', () => {
+    // Should not throw or produce NaN
+    const tokens = estimateTokenCount(asciiString(1_000))
+    expect(tokens).toBeGreaterThan(0)
+    expect(Number.isFinite(tokens)).toBe(true)
+  })
+})
+
+// ─── truncateToolOutput ───────────────────────────────────────────────────────
+
+describe('truncateToolOutput', () => {
+  it('returns the original string when below the token threshold', () => {
+    // 100 ASCII chars → 25 tokens, well below 2 000
+    const small = asciiString(100)
+    expect(truncateToolOutput(small)).toBe(small)
+  })
+
+  it('returns the original string when exactly at the threshold', () => {
+    // Exactly DEFAULT_TOKEN_THRESHOLD tokens worth of ASCII chars
+    const atThreshold = asciiString(DEFAULT_TOKEN_THRESHOLD * 4)
+    expect(truncateToolOutput(atThreshold)).toBe(atThreshold)
+  })
+
+  it('truncates output that exceeds the threshold', () => {
+    // 2× the threshold → should be truncated
+    const big = asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 2)
+    const result = truncateToolOutput(big)
+    expect(result.length).toBeLessThan(big.length)
+  })
+
+  it('inserts a truncation marker between head and tail', () => {
+    const big = asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 2)
+    const result = truncateToolOutput(big)
+    expect(result).toContain('Output truncated')
+    expect(result).toContain('tokens omitted')
+  })
+
+  it('marker includes total line count', () => {
+    // 3 lines, oversized
+    const text = ('x'.repeat(5_000) + '\n').repeat(3)
+    const result = truncateToolOutput(text)
+    expect(result).toMatch(/\d+ lines total/)
+  })
+
+  it('marker reports head and tail token counts', () => {
+    const big = asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 2)
+    const result = truncateToolOutput(big)
+    const headTokens = Math.floor(DEFAULT_TOKEN_THRESHOLD * DEFAULT_HEAD_RATIO)
+    const tailTokens = DEFAULT_TOKEN_THRESHOLD - headTokens
+    expect(result).toContain(`~${headTokens} tokens`)
+    expect(result).toContain(`~${tailTokens} tokens`)
+  })
+
+  it('head slice starts from the beginning of the string', () => {
+    const big = 'START' + asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 2) + 'END'
+    const result = truncateToolOutput(big)
+    expect(result.startsWith('START')).toBe(true)
+  })
+
+  it('tail slice ends at the end of the string', () => {
+    const big = 'START' + asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 2) + 'END'
+    const result = truncateToolOutput(big)
+    expect(result.endsWith('END')).toBe(true)
+  })
+
+  it('respects a custom tokenThreshold', () => {
+    const smallThreshold = 100
+    // 200 ASCII chars → 50 tokens → above 100-token threshold? No: 50 < 100.
+    // Use 500 chars → 125 tokens → above 100.
+    const text = asciiString(500)
+    const result = truncateToolOutput(text, { tokenThreshold: smallThreshold })
+    expect(result).toContain('Output truncated')
+  })
+
+  it('does not truncate when tokenThreshold is very large', () => {
+    const text = asciiString(1_000)
+    const result = truncateToolOutput(text, { tokenThreshold: 1_000_000 })
+    expect(result).toBe(text)
+  })
+
+  it('respects a custom headRatio of 0 (all tail)', () => {
+    const big = 'HEAD' + asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 2) + 'TAIL'
+    const result = truncateToolOutput(big, { headRatio: 0 })
+    // Head slice is 0 chars → result should not start with 'HEAD'
+    // (the marker comes immediately, then the tail portion)
+    expect(result).toContain('TAIL')
+    expect(result).toContain('Output truncated')
+  })
+
+  it('respects a custom headRatio of 1 (all head)', () => {
+    const big = 'HEAD' + asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 2) + 'TAIL'
+    const result = truncateToolOutput(big, { headRatio: 1 })
+    // Tail budget is 0, so tail is the full string (slicing from length-0 returns the whole string).
+    // The important thing is the marker appears and no crash occurs.
+    expect(result).toContain('Output truncated')
+    expect(result).toContain('HEAD')
+  })
+
+  it('handles an empty string without errors', () => {
+    expect(truncateToolOutput('')).toBe('')
+  })
+
+  it('handles a single-character string without errors', () => {
+    expect(truncateToolOutput('x')).toBe('x')
+  })
+
+  it('clamps headRatio values outside [0,1]', () => {
+    const big = asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 2)
+    // Should not throw for out-of-range ratios
+    expect(() => truncateToolOutput(big, { headRatio: -1 })).not.toThrow()
+    expect(() => truncateToolOutput(big, { headRatio: 2 })).not.toThrow()
+  })
+
+  it('works correctly with non-ASCII (CJK) content', () => {
+    // CJK is denser in tokens, so fewer chars needed to exceed the threshold.
+    // 2000 CJK chars → ~2597 tokens → above DEFAULT_TOKEN_THRESHOLD
+    const cjk = cjkString(2_000)
+    const result = truncateToolOutput(cjk)
+    expect(result).toContain('Output truncated')
+    expect(result.length).toBeLessThan(cjk.length)
+  })
+
+  it('truncated output is shorter than the original', () => {
+    const big = asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 3)
+    const result = truncateToolOutput(big)
+    expect(result.length).toBeLessThan(big.length)
+  })
+})
+
+// ─── truncateShellOutput ──────────────────────────────────────────────────────
+
+describe('truncateShellOutput', () => {
+  const bigStdout = asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 2)
+  const stderr = 'error: something went wrong\nfatal: cannot continue'
+  const exitCode = 1
+
+  it('truncates stdout when it exceeds the threshold', () => {
+    const result = truncateShellOutput({ stdout: bigStdout, stderr, exitCode })
+    expect(result.stdout).toContain('Output truncated')
+    expect(result.stdout.length).toBeLessThan(bigStdout.length)
+  })
+
+  it('preserves stderr in full, regardless of size', () => {
+    const longStderr = asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 5)
+    const result = truncateShellOutput({
+      stdout: bigStdout,
+      stderr: longStderr,
+      exitCode,
+    })
+    // stderr must be returned exactly as-is
+    expect(result.stderr).toBe(longStderr)
+  })
+
+  it('preserves exitCode regardless of stdout size', () => {
+    const result = truncateShellOutput({ stdout: bigStdout, stderr, exitCode })
+    expect(result.exitCode).toBe(exitCode)
+  })
+
+  it('preserves a non-zero exitCode', () => {
+    const result = truncateShellOutput({ stdout: bigStdout, stderr, exitCode: 127 })
+    expect(result.exitCode).toBe(127)
+  })
+
+  it('does not truncate small stdout', () => {
+    const small = asciiString(100)
+    const result = truncateShellOutput({ stdout: small, stderr, exitCode: 0 })
+    expect(result.stdout).toBe(small)
+  })
+
+  it('passes options through to truncateToolOutput', () => {
+    const smallThreshold = 50 // very low threshold
+    const text = asciiString(300) // 75 tokens → above 50
+    const result = truncateShellOutput(
+      { stdout: text, stderr: '', exitCode: 0 },
+      { tokenThreshold: smallThreshold },
+    )
+    expect(result.stdout).toContain('Output truncated')
+  })
+
+  it('handles empty stdout without errors', () => {
+    const result = truncateShellOutput({ stdout: '', stderr: 'err', exitCode: 1 })
+    expect(result.stdout).toBe('')
+    expect(result.stderr).toBe('err')
+    expect(result.exitCode).toBe(1)
+  })
+})
+
+// ─── applyToolOutputTruncation ────────────────────────────────────────────────
+
+describe('applyToolOutputTruncation', () => {
+  const bigOutput = asciiString(DEFAULT_TOKEN_THRESHOLD * 4 * 2)
+
+  it('truncates output for a non-exempt tool', () => {
+    const result = applyToolOutputTruncation('Bash', bigOutput)
+    expect(result).toContain('Output truncated')
+    expect(result.length).toBeLessThan(bigOutput.length)
+  })
+
+  it('passes through output for every exempt tool unchanged', () => {
+    for (const tool of TRUNCATION_EXEMPT_TOOLS) {
+      expect(applyToolOutputTruncation(tool, bigOutput)).toBe(bigOutput)
+    }
+  })
+
+  it('is case-sensitive — "edit" (lowercase) is not exempt', () => {
+    const result = applyToolOutputTruncation('edit', bigOutput)
+    // 'edit' ≠ 'Edit' → should be truncated
+    expect(result).toContain('Output truncated')
+  })
+
+  it('forwards custom options to truncateToolOutput', () => {
+    const smallThreshold = 50
+    const text = asciiString(300) // 75 tokens
+    const result = applyToolOutputTruncation('Bash', text, {
+      tokenThreshold: smallThreshold,
+    })
+    expect(result).toContain('Output truncated')
+  })
+
+  it('does not truncate small output from non-exempt tools', () => {
+    const small = asciiString(100) // 25 tokens, well below threshold
+    expect(applyToolOutputTruncation('Bash', small)).toBe(small)
+  })
+
+  it('handles unknown tool names without throwing', () => {
+    expect(() =>
+      applyToolOutputTruncation('SomeUnknownTool', bigOutput),
+    ).not.toThrow()
+  })
+
+  it('handles an empty tool name without throwing', () => {
+    expect(() => applyToolOutputTruncation('', bigOutput)).not.toThrow()
+  })
+
+  it('handles empty output for any tool without throwing', () => {
+    expect(applyToolOutputTruncation('Bash', '')).toBe('')
+    expect(applyToolOutputTruncation('Edit', '')).toBe('')
+  })
+})
+
+// ─── TRUNCATION_EXEMPT_TOOLS set ─────────────────────────────────────────────
+
+describe('TRUNCATION_EXEMPT_TOOLS', () => {
+  it('includes Edit', () => {
+    expect(TRUNCATION_EXEMPT_TOOLS.has('Edit')).toBe(true)
+  })
+
+  it('includes Write', () => {
+    expect(TRUNCATION_EXEMPT_TOOLS.has('Write')).toBe(true)
+  })
+
+  it('includes AskUser', () => {
+    expect(TRUNCATION_EXEMPT_TOOLS.has('AskUser')).toBe(true)
+  })
+
+  it('does not include Bash', () => {
+    expect(TRUNCATION_EXEMPT_TOOLS.has('Bash')).toBe(false)
+  })
+
+  it('does not include Grep', () => {
+    expect(TRUNCATION_EXEMPT_TOOLS.has('Grep')).toBe(false)
+  })
+
+  it('does not include Read', () => {
+    expect(TRUNCATION_EXEMPT_TOOLS.has('Read')).toBe(false)
+  })
+})

--- a/cli/toolOutputTruncation.ts
+++ b/cli/toolOutputTruncation.ts
@@ -1,0 +1,202 @@
+/**
+ * Tool output truncation with head+tail strategy.
+ *
+ * Large tool outputs (shell commands, grep results, file reads) can consume
+ * enormous context budgets — a single command can add 10K+ tokens, most of
+ * which the model never uses. This module intercepts tool results before they
+ * are appended to message history and trims them to a configurable token budget
+ * while retaining the parts most likely to matter: the beginning (context /
+ * headers / early errors) and the end (final results / last error lines).
+ *
+ * Design principles:
+ *   - No API calls — token counts are estimated via a character-density heuristic.
+ *   - Outputs below the threshold pass through completely unchanged.
+ *   - Shell results preserve stderr and exit codes unconditionally; only stdout
+ *     is eligible for truncation.
+ *   - A small set of tools (Edit, Write, AskUser, …) are exempt because their
+ *     outputs are either already short or must be read in full for correctness.
+ *   - The truncation marker records line counts and token estimates so the model
+ *     (and humans reviewing transcripts) can understand what was dropped.
+ */
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Default token threshold — outputs at or below this pass through unchanged. */
+export const DEFAULT_TOKEN_THRESHOLD = 2_000
+
+/** Default fraction of the budget kept from the head of the output. */
+export const DEFAULT_HEAD_RATIO = 0.2
+
+/**
+ * ASCII character density heuristic: roughly 4 characters per token for
+ * plain English / code text.
+ */
+const ASCII_CHARS_PER_TOKEN = 4
+
+/**
+ * Non-ASCII character density: roughly 0.77 characters per token on average
+ * (CJK glyphs and other multibyte sequences require more bytes per codepoint).
+ */
+const NON_ASCII_CHARS_PER_TOKEN = 0.77
+
+/** Number of characters sampled to determine the ASCII vs non-ASCII ratio. */
+const SAMPLE_SIZE = 1_000
+
+/**
+ * Tools exempt from truncation. Their outputs are either inherently small
+ * (Edit confirms a diff; AskUser echoes the answer) or must be read in full
+ * for downstream correctness (Write, TodoWrite).
+ */
+export const TRUNCATION_EXEMPT_TOOLS = new Set([
+  'Edit',
+  'MultiEdit',
+  'Write',
+  'AskUser',
+  'AskFollowupQuestion',
+  'TodoRead',
+  'TodoWrite',
+])
+
+// ─── Token estimation ─────────────────────────────────────────────────────────
+
+/**
+ * Estimate the token count of a string using a character-density heuristic.
+ *
+ * Samples the first SAMPLE_SIZE characters to determine the ASCII fraction,
+ * then blends the ASCII and non-ASCII chars-per-token rates proportionally
+ * before dividing the full string length by that blended rate.
+ *
+ * This is intentionally an approximation — the goal is a fast gate that avoids
+ * unnecessary truncation of small outputs, not an exact token count.
+ */
+export function estimateTokenCount(text: string): number {
+  if (text.length === 0) return 0
+
+  const sample = text.slice(0, SAMPLE_SIZE)
+  let asciiCount = 0
+  for (let i = 0; i < sample.length; i++) {
+    if (sample.charCodeAt(i) < 128) asciiCount++
+  }
+
+  const asciiRatio = asciiCount / sample.length
+  const charsPerToken =
+    asciiRatio * ASCII_CHARS_PER_TOKEN +
+    (1 - asciiRatio) * NON_ASCII_CHARS_PER_TOKEN
+
+  return Math.ceil(text.length / charsPerToken)
+}
+
+// ─── Head+tail truncation ─────────────────────────────────────────────────────
+
+export type TruncationOptions = {
+  /**
+   * Maximum tokens before truncation is applied.
+   * @default DEFAULT_TOKEN_THRESHOLD (2 000)
+   */
+  tokenThreshold?: number
+  /**
+   * Fraction of the token budget kept from the head of the output.
+   * Must be in [0, 1]. The remainder goes to the tail.
+   * @default DEFAULT_HEAD_RATIO (0.2)
+   */
+  headRatio?: number
+}
+
+/**
+ * Truncate a string using a head+tail strategy.
+ *
+ * - Strings within the token threshold pass through unchanged.
+ * - For larger strings: `headRatio * threshold` tokens are kept from the start;
+ *   `(1 - headRatio) * threshold` tokens from the end. A descriptive marker is
+ *   inserted between the two retained slices, reporting total line count and
+ *   the estimated number of omitted tokens.
+ *
+ * Character slicing uses the ASCII chars-per-token rate as a conservative
+ * upper bound — slightly over-preserving characters is safer than cutting too
+ * aggressively.
+ */
+export function truncateToolOutput(
+  text: string,
+  options: TruncationOptions = {},
+): string {
+  const threshold = options.tokenThreshold ?? DEFAULT_TOKEN_THRESHOLD
+  const headRatio = Math.max(0, Math.min(1, options.headRatio ?? DEFAULT_HEAD_RATIO))
+
+  const estimated = estimateTokenCount(text)
+  if (estimated <= threshold) return text
+
+  const totalLines = text.split('\n').length
+
+  const headTokens = Math.floor(threshold * headRatio)
+  const tailTokens = threshold - headTokens
+
+  // ASCII chars-per-token gives the most conservative (largest) character
+  // estimate — we err toward keeping more context rather than less.
+  const headChars = headTokens * ASCII_CHARS_PER_TOKEN
+  const tailChars = tailTokens * ASCII_CHARS_PER_TOKEN
+
+  const head = text.slice(0, headChars)
+  const tail = text.length > tailChars ? text.slice(text.length - tailChars) : text
+
+  const omittedTokens = estimated - threshold
+
+  const marker = [
+    '',
+    `\u2502 [Output truncated: ${totalLines} lines total, ~${omittedTokens} tokens omitted]`,
+    `\u2502 [Showing first ~${headTokens} tokens and last ~${tailTokens} tokens]`,
+    '',
+  ].join('\n')
+
+  return head + marker + tail
+}
+
+// ─── Shell output handling ────────────────────────────────────────────────────
+
+export type ShellOutput = {
+  /** Standard output from the command. Subject to truncation. */
+  stdout: string
+  /** Standard error from the command. Always preserved in full. */
+  stderr: string
+  /** Process exit code. Always preserved. */
+  exitCode: number
+}
+
+/**
+ * Truncate shell command output while preserving stderr and exit code.
+ *
+ * Stderr and the exit code are diagnostic signals that must not be lost —
+ * they are the primary indicators of command failure. Only stdout is
+ * eligible for truncation.
+ */
+export function truncateShellOutput(
+  output: ShellOutput,
+  options: TruncationOptions = {},
+): ShellOutput {
+  return {
+    ...output,
+    stdout: truncateToolOutput(output.stdout, options),
+  }
+}
+
+// ─── Primary entry point ──────────────────────────────────────────────────────
+
+/**
+ * Apply truncation to a tool result string, respecting tool exemptions.
+ *
+ * This is the function to call at the tool-result interception point before
+ * appending to message history. Exempt tools return their output unchanged;
+ * all others go through `truncateToolOutput`.
+ *
+ * @param toolName - The name of the tool that produced the output.
+ * @param output   - The raw tool output string.
+ * @param options  - Optional truncation configuration.
+ * @returns The (possibly truncated) output string.
+ */
+export function applyToolOutputTruncation(
+  toolName: string,
+  output: string,
+  options: TruncationOptions = {},
+): string {
+  if (TRUNCATION_EXEMPT_TOOLS.has(toolName)) return output
+  return truncateToolOutput(output, options)
+}


### PR DESCRIPTION
## Summary
- Character-density heuristic for token estimation (no API calls)
- Head+tail split: 20% head / 80% tail within a 2K token budget
- Shell outputs: stderr and exit code always preserved in full
- Exempt tools (Edit, Write, AskUser, …) bypass truncation entirely
- Truncation marker reports total line count and tokens omitted
- 40+ unit tests covering ASCII, non-ASCII, edge cases, all public APIs

Closes #1